### PR TITLE
Fix PreviewGoto on Windows

### DIFF
--- a/autoload/preview.vim
+++ b/autoload/preview.vim
@@ -568,10 +568,10 @@ function! preview#preview_goto(cmd)
 	let [l:tabnr, l:winnr] = preview#window_find(pid)
 	silent! wincmd P
 	let l:bufnr = winbufnr(l:winnr)
-	let l:bufname = bufname(l:bufnr)
+	let l:bufpath = expand("#".l:bufnr.":p")
 	let l:line = line('.')
 	call preview#window_goto_uid(uid)
-	silent exec a:cmd.' '.fnameescape(l:bufname)
+	silent exec a:cmd.' '.fnameescape(l:bufpath)
 	if winbufnr('%') == l:bufnr
 		silent exec ''.l:line
 		call preview#window_up(0)


### PR DESCRIPTION
On Windows, PreviewGoto would fail to open the file because it is from another directory. With this patch, the goto command always succeeds because it uses the fully expanded path instead of the buffer name.